### PR TITLE
feat: Forum, Information 게시판 및 User API 구현

### DIFF
--- a/src/main/java/kusuri12/teens_be/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/kusuri12/teens_be/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,17 @@
+package kusuri12.teens_be.domain.comment.repository;
+
+import kusuri12.teens_be.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    Long countByForumId(Long forumId);
+
+    Long countByUserId(Long userId);
+
+    List<Comment> findByForumIdOrderByCreatedAtAsc(Long forumId);
+}

--- a/src/main/java/kusuri12/teens_be/domain/forum/controller/ForumController.java
+++ b/src/main/java/kusuri12/teens_be/domain/forum/controller/ForumController.java
@@ -1,0 +1,41 @@
+package kusuri12.teens_be.domain.forum.controller;
+
+import kusuri12.teens_be.domain.forum.dto.ForumDto;
+import kusuri12.teens_be.domain.forum.service.ForumService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/forum")
+@RequiredArgsConstructor
+public class ForumController {
+
+    private final ForumService forumService;
+
+    @GetMapping
+    public ResponseEntity<List<ForumDto.ForumListResponse>> getAllForums() {
+        return ResponseEntity.ok(forumService.getAllForums());
+    }
+
+    @GetMapping("/{forumId}")
+    public ResponseEntity<ForumDto.ForumDetailResponse> getForumDetail(@PathVariable Long forumId) {
+        return ResponseEntity.ok(forumService.getForumDetail(forumId));
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> createForum(@RequestBody ForumDto.CreateForumRequest request) {
+        forumService.createForum(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{forumId}/comments")
+    public ResponseEntity<Void> createComment(
+            @PathVariable Long forumId,
+            @RequestBody ForumDto.CreateCommentRequest request) {
+        forumService.createComment(forumId, request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/kusuri12/teens_be/domain/forum/dto/ForumDto.java
+++ b/src/main/java/kusuri12/teens_be/domain/forum/dto/ForumDto.java
@@ -1,0 +1,65 @@
+package kusuri12.teens_be.domain.forum.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ForumDto {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ForumListResponse {
+        private Long id;
+        private String title;
+        private String authorName;
+        private LocalDateTime createdAt;
+        private Long commentCount;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ForumDetailResponse {
+        private Long id;
+        private String title;
+        private String content;
+        private String authorName;
+        private LocalDateTime createdAt;
+        private List<CommentResponse> comments;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CommentResponse {
+        private Long id;
+        private String content;
+        private String authorName;
+        private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CreateForumRequest {
+        private String title;
+        private String content;
+        private Long userId;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CreateCommentRequest {
+        private String content;
+        private Long userId;
+    }
+}

--- a/src/main/java/kusuri12/teens_be/domain/forum/repository/ForumRepository.java
+++ b/src/main/java/kusuri12/teens_be/domain/forum/repository/ForumRepository.java
@@ -1,0 +1,17 @@
+package kusuri12.teens_be.domain.forum.repository;
+
+import kusuri12.teens_be.domain.forum.entity.Forum;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ForumRepository extends JpaRepository<Forum, Long> {
+
+    @Query("SELECT f FROM Forum f ORDER BY f.createdAt DESC")
+    List<Forum> findAllOrderByCreatedAtDesc();
+
+    Long countByUserId(Long userId);
+}

--- a/src/main/java/kusuri12/teens_be/domain/forum/service/ForumService.java
+++ b/src/main/java/kusuri12/teens_be/domain/forum/service/ForumService.java
@@ -1,0 +1,97 @@
+package kusuri12.teens_be.domain.forum.service;
+
+import kusuri12.teens_be.domain.comment.entity.Comment;
+import kusuri12.teens_be.domain.comment.repository.CommentRepository;
+import kusuri12.teens_be.domain.forum.dto.ForumDto;
+import kusuri12.teens_be.domain.forum.entity.Forum;
+import kusuri12.teens_be.domain.forum.repository.ForumRepository;
+import kusuri12.teens_be.domain.user.entity.User;
+import kusuri12.teens_be.domain.user.repository.UserRepository;
+import kusuri12.teens_be.global.error.exception.CustomException;
+import kusuri12.teens_be.global.error.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ForumService {
+
+    private final ForumRepository forumRepository;
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+
+    public List<ForumDto.ForumListResponse> getAllForums() {
+        List<Forum> forums = forumRepository.findAllOrderByCreatedAtDesc();
+
+        return forums.stream()
+                .map(forum -> ForumDto.ForumListResponse.builder()
+                        .id(forum.getId())
+                        .title(forum.getTitle())
+                        .authorName(forum.getUser().getNickname())
+                        .createdAt(forum.getCreatedAt())
+                        .commentCount(commentRepository.countByForumId(forum.getId()))
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    public ForumDto.ForumDetailResponse getForumDetail(Long forumId) {
+        Forum forum = forumRepository.findById(forumId)
+                .orElseThrow(() -> new CustomException(ErrorCode.FORUM_NOT_FOUND));
+
+        List<Comment> comments = commentRepository.findByForumIdOrderByCreatedAtAsc(forumId);
+
+        List<ForumDto.CommentResponse> commentResponses = comments.stream()
+                .map(comment -> ForumDto.CommentResponse.builder()
+                        .id(comment.getId())
+                        .content(comment.getContent())
+                        .authorName(comment.getUser().getNickname())
+                        .createdAt(comment.getCreatedAt())
+                        .build())
+                .collect(Collectors.toList());
+
+        return ForumDto.ForumDetailResponse.builder()
+                .id(forum.getId())
+                .title(forum.getTitle())
+                .content(forum.getContent())
+                .authorName(forum.getUser().getNickname())
+                .createdAt(forum.getCreatedAt())
+                .comments(commentResponses)
+                .build();
+    }
+
+    @Transactional
+    public void createForum(ForumDto.CreateForumRequest request) {
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Forum forum = Forum.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .user(user)
+                .build();
+
+        forumRepository.save(forum);
+    }
+
+    @Transactional
+    public void createComment(Long forumId, ForumDto.CreateCommentRequest request) {
+        Forum forum = forumRepository.findById(forumId)
+                .orElseThrow(() -> new CustomException(ErrorCode.FORUM_NOT_FOUND));
+
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Comment comment = Comment.builder()
+                .content(request.getContent())
+                .forum(forum)
+                .user(user)
+                .build();
+
+        commentRepository.save(comment);
+    }
+}

--- a/src/main/java/kusuri12/teens_be/domain/information/controller/InfoArticleController.java
+++ b/src/main/java/kusuri12/teens_be/domain/information/controller/InfoArticleController.java
@@ -1,0 +1,33 @@
+package kusuri12.teens_be.domain.information.controller;
+
+import kusuri12.teens_be.domain.information.dto.InfoArticleDto;
+import kusuri12.teens_be.domain.information.service.InfoArticleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/information")
+@RequiredArgsConstructor
+public class InfoArticleController {
+
+    private final InfoArticleService infoArticleService;
+
+    @GetMapping
+    public ResponseEntity<List<InfoArticleDto.InfoArticleListResponse>> getAllInfoArticles() {
+        return ResponseEntity.ok(infoArticleService.getAllInfoArticles());
+    }
+
+    @GetMapping("/{articleId}")
+    public ResponseEntity<InfoArticleDto.InfoArticleDetailResponse> getInfoArticleDetail(@PathVariable Long articleId) {
+        return ResponseEntity.ok(infoArticleService.getInfoArticleDetail(articleId));
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> createInfoArticle(@RequestBody InfoArticleDto.CreateInfoArticleRequest request) {
+        infoArticleService.createInfoArticle(request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/kusuri12/teens_be/domain/information/dto/InfoArticleDto.java
+++ b/src/main/java/kusuri12/teens_be/domain/information/dto/InfoArticleDto.java
@@ -1,0 +1,47 @@
+package kusuri12.teens_be.domain.information.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class InfoArticleDto {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class InfoArticleListResponse {
+        private Long id;
+        private String title;
+        private String authorName;
+        private LocalDateTime createdAt;
+        private boolean pinned;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class InfoArticleDetailResponse {
+        private Long id;
+        private String title;
+        private String content;
+        private String authorName;
+        private LocalDateTime createdAt;
+        private String imageUrl;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CreateInfoArticleRequest {
+        private String title;
+        private String content;
+        private Long userId;
+        private boolean pinned;
+        private String imageUrl;
+    }
+}

--- a/src/main/java/kusuri12/teens_be/domain/information/entity/InfoArticle.java
+++ b/src/main/java/kusuri12/teens_be/domain/information/entity/InfoArticle.java
@@ -1,0 +1,42 @@
+package kusuri12.teens_be.domain.information.entity;
+
+import jakarta.persistence.*;
+import kusuri12.teens_be.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class InfoArticle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private boolean pinned = false;
+
+    @Column
+    private String imageUrl;
+}

--- a/src/main/java/kusuri12/teens_be/domain/information/repository/InfoArticleRepository.java
+++ b/src/main/java/kusuri12/teens_be/domain/information/repository/InfoArticleRepository.java
@@ -1,0 +1,15 @@
+package kusuri12.teens_be.domain.information.repository;
+
+import kusuri12.teens_be.domain.information.entity.InfoArticle;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface InfoArticleRepository extends JpaRepository<InfoArticle, Long> {
+
+    @Query("SELECT i FROM InfoArticle i ORDER BY i.pinned DESC, i.createdAt DESC")
+    List<InfoArticle> findAllOrderByPinnedAndCreatedAt();
+}

--- a/src/main/java/kusuri12/teens_be/domain/information/service/InfoArticleService.java
+++ b/src/main/java/kusuri12/teens_be/domain/information/service/InfoArticleService.java
@@ -1,0 +1,68 @@
+package kusuri12.teens_be.domain.information.service;
+
+import kusuri12.teens_be.domain.information.dto.InfoArticleDto;
+import kusuri12.teens_be.domain.information.entity.InfoArticle;
+import kusuri12.teens_be.domain.information.repository.InfoArticleRepository;
+import kusuri12.teens_be.domain.user.entity.User;
+import kusuri12.teens_be.domain.user.repository.UserRepository;
+import kusuri12.teens_be.global.error.exception.CustomException;
+import kusuri12.teens_be.global.error.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InfoArticleService {
+
+    private final InfoArticleRepository infoArticleRepository;
+    private final UserRepository userRepository;
+
+    public List<InfoArticleDto.InfoArticleListResponse> getAllInfoArticles() {
+        List<InfoArticle> articles = infoArticleRepository.findAllOrderByPinnedAndCreatedAt();
+
+        return articles.stream()
+                .map(article -> InfoArticleDto.InfoArticleListResponse.builder()
+                        .id(article.getId())
+                        .title(article.getTitle())
+                        .authorName(article.getUser().getNickname())
+                        .createdAt(article.getCreatedAt())
+                        .pinned(article.isPinned())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    public InfoArticleDto.InfoArticleDetailResponse getInfoArticleDetail(Long articleId) {
+        InfoArticle article = infoArticleRepository.findById(articleId)
+                .orElseThrow(() -> new CustomException(ErrorCode.INFO_ARTICLE_NOT_FOUND));
+
+        return InfoArticleDto.InfoArticleDetailResponse.builder()
+                .id(article.getId())
+                .title(article.getTitle())
+                .content(article.getContent())
+                .authorName(article.getUser().getNickname())
+                .createdAt(article.getCreatedAt())
+                .imageUrl(article.getImageUrl())
+                .build();
+    }
+
+    @Transactional
+    public void createInfoArticle(InfoArticleDto.CreateInfoArticleRequest request) {
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        InfoArticle article = InfoArticle.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .user(user)
+                .pinned(request.isPinned())
+                .imageUrl(request.getImageUrl())
+                .build();
+
+        infoArticleRepository.save(article);
+    }
+}

--- a/src/main/java/kusuri12/teens_be/domain/user/controller/UserController.java
+++ b/src/main/java/kusuri12/teens_be/domain/user/controller/UserController.java
@@ -1,0 +1,20 @@
+package kusuri12.teens_be.domain.user.controller;
+
+import kusuri12.teens_be.domain.user.dto.UserDto;
+import kusuri12.teens_be.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<UserDto.UserMeResponse> getUserMe(@RequestParam Long userId) {
+        return ResponseEntity.ok(userService.getUserMe(userId));
+    }
+}

--- a/src/main/java/kusuri12/teens_be/domain/user/dto/UserDto.java
+++ b/src/main/java/kusuri12/teens_be/domain/user/dto/UserDto.java
@@ -1,0 +1,23 @@
+package kusuri12.teens_be.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserDto {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UserMeResponse {
+        private Long id;
+        private String username;
+        private String nickname;
+        private String email;
+        private String role;
+        private Long forumCount;
+        private Long commentCount;
+    }
+}

--- a/src/main/java/kusuri12/teens_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/kusuri12/teens_be/domain/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package kusuri12.teens_be.domain.user.repository;
+
+import kusuri12.teens_be.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/kusuri12/teens_be/domain/user/service/UserService.java
+++ b/src/main/java/kusuri12/teens_be/domain/user/service/UserService.java
@@ -1,0 +1,40 @@
+package kusuri12.teens_be.domain.user.service;
+
+import kusuri12.teens_be.domain.comment.repository.CommentRepository;
+import kusuri12.teens_be.domain.forum.repository.ForumRepository;
+import kusuri12.teens_be.domain.user.dto.UserDto;
+import kusuri12.teens_be.domain.user.entity.User;
+import kusuri12.teens_be.domain.user.repository.UserRepository;
+import kusuri12.teens_be.global.error.exception.CustomException;
+import kusuri12.teens_be.global.error.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final ForumRepository forumRepository;
+    private final CommentRepository commentRepository;
+
+    public UserDto.UserMeResponse getUserMe(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Long forumCount = forumRepository.countByUserId(userId);
+        Long commentCount = commentRepository.countByUserId(userId);
+
+        return UserDto.UserMeResponse.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .role(user.getRole().name())
+                .forumCount(forumCount)
+                .commentCount(commentCount)
+                .build();
+    }
+}

--- a/src/main/java/kusuri12/teens_be/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/kusuri12/teens_be/global/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package kusuri12.teens_be.global.error;
 
+import kusuri12.teens_be.global.error.exception.CustomException;
 import kusuri12.teens_be.global.error.exception.ErrorCode;
 import kusuri12.teens_be.global.error.exception.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -11,6 +12,21 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+    // CustomException 처리
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        log.error("CustomException: ", e);
+
+        ErrorCode errorCode = e.getErrorCode();
+        ErrorResponse response = ErrorResponse.builder()
+                .httpStatus(errorCode.getStatus())
+                .message(errorCode.getMessage())
+                .build();
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(response);
+    }
 
     // 예상하지 못한 에러 처리
     @ExceptionHandler(Exception.class)

--- a/src/main/java/kusuri12/teens_be/global/error/exception/CustomException.java
+++ b/src/main/java/kusuri12/teens_be/global/error/exception/CustomException.java
@@ -1,0 +1,13 @@
+package kusuri12.teens_be.global.error.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/kusuri12/teens_be/global/error/exception/ErrorCode.java
+++ b/src/main/java/kusuri12/teens_be/global/error/exception/ErrorCode.java
@@ -1,6 +1,5 @@
 package kusuri12.teens_be.global.error.exception;
 
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
@@ -11,6 +10,8 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "User Not Found"),
     USERNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "Username Already Exists"),
     PASSWORD_INCORRECT(HttpStatus.BAD_REQUEST, "Password Incorrect"),
+    FORUM_NOT_FOUND(HttpStatus.NOT_FOUND, "Forum Not Found"),
+    INFO_ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "Info Article Not Found"),
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error");
 


### PR DESCRIPTION
Forum - 티키타카 게시판
- Forum entity, Repository, Service, Controller, DTO 구현
- GET/forum: 게시글 목록 조회(제목, 작성자, 작성시간, 댓글 개수)
- GET/forum/{id} : 게시글 상세 조회(내용, 댓글 목록 포함)
- POST/forum : 게시글 작성
- POST/forum/{id}/comments : 댓글 작성
- 댓글은 오름차순으로 정렬

Information - 정보 게시판
- InfoArticle 엔티티, Repository, Service, Controller, DTO 구현
- GET/information : 정보글 목록 조회 (고정글 최상단 정렬)
- GET/information/{id} : 정보글 상세 조회(이미지 URL 포함)
- POST/information : 정보글 작성
- pinned 필드로 공지글 고정 기능 지원

User - 사용자 API 구현
 - UserService, UserController, UserDto 구현
- GET/user/me : 사용자 정보, 활동 통계 조회
- 작성한 게시글 개수, 댓글 개수 통계 제공
- ForumRepository.countByUserId() 메서드 추가
- CommentRepository.countByUserId() 메서드 추가

예외 처리
- CustomException 클래스 추가
- GlobalExceptionHandler에 CustomException 핸들러 추가
- ErrorCode에 FORUM_NOT_FOUND, INFO_ARTICLE_NOT_FOUND 추가
- 일관된 JSON 에러 응답 구조 구현

엔티티 관계
- User-Forum: 1:N 관계
- User-Comment: 1:N 관계
- User-InfoArticle: 1:N 관계
- Forum-Comment: 1:N 관계
- CascadeType.REMOVE로 연관 데이터 자동 삭제 설정