### PR TITLE
fix: authcontroller 외 일부 픽스

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }
 
 tasks.named('test') {

--- a/src/main/java/kusuri12/teens_be/TeensBeApplication.java
+++ b/src/main/java/kusuri12/teens_be/TeensBeApplication.java
@@ -1,9 +1,12 @@
 package kusuri12.teens_be;
 
+import kusuri12.teens_be.global.jwt.JwtProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(JwtProperties.class)
 public class TeensBeApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/kusuri12/teens_be/domain/auth/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/kusuri12/teens_be/domain/auth/domain/repository/RefreshTokenRepository.java
@@ -5,6 +5,5 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
-    RefreshToken findByToken(String token);
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
 }

--- a/src/main/java/kusuri12/teens_be/domain/auth/presentation/AuthController.java
+++ b/src/main/java/kusuri12/teens_be/domain/auth/presentation/AuthController.java
@@ -2,14 +2,14 @@ package kusuri12.teens_be.domain.auth.presentation;
 
 import jakarta.validation.Valid;
 import kusuri12.teens_be.domain.auth.presentation.dto.request.CheckIdRequest;
-import kusuri12.teens_be.domain.auth.presentation.dto.request.RefreshTokenRequest;
+import kusuri12.teens_be.domain.auth.presentation.dto.request.ReissueRequest;
 import kusuri12.teens_be.domain.auth.presentation.dto.request.SignInRequest;
 import kusuri12.teens_be.domain.auth.presentation.dto.request.SignUpRequest;
 import kusuri12.teens_be.domain.auth.presentation.dto.response.CheckIdResponse;
 import kusuri12.teens_be.domain.auth.presentation.dto.response.SignInResponse;
-import kusuri12.teens_be.domain.auth.presentation.dto.response.TokenResponse;
 import kusuri12.teens_be.domain.auth.service.*;
 import kusuri12.teens_be.global.auth.AuthDetails;
+import kusuri12.teens_be.global.jwt.JwtTokens;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -61,8 +61,8 @@ public class AuthController {
     }
 
     @PostMapping("/reissue")
-    public ResponseEntity<TokenResponse> reissue(
-            @RequestBody RefreshTokenRequest request) {
+    public ResponseEntity<JwtTokens> reissue(
+            @RequestBody ReissueRequest request) {
         return ResponseEntity.ok(reissueService.reissue(request));
     }
 }

--- a/src/main/java/kusuri12/teens_be/domain/auth/presentation/dto/request/ReissueRequest.java
+++ b/src/main/java/kusuri12/teens_be/domain/auth/presentation/dto/request/ReissueRequest.java
@@ -1,6 +1,6 @@
 package kusuri12.teens_be.domain.auth.presentation.dto.request;
 
-public record RefreshTokenRequest(
+public record ReissueRequest(
         String refreshToken
 ) {
 }

--- a/src/main/java/kusuri12/teens_be/domain/auth/presentation/dto/response/TokenResponse.java
+++ b/src/main/java/kusuri12/teens_be/domain/auth/presentation/dto/response/TokenResponse.java
@@ -1,7 +1,0 @@
-package kusuri12.teens_be.domain.auth.presentation.dto.response;
-
-public record TokenResponse(
-        String accessToken,
-        String refreshToken
-) {
-}

--- a/src/main/java/kusuri12/teens_be/domain/auth/service/ReissueService.java
+++ b/src/main/java/kusuri12/teens_be/domain/auth/service/ReissueService.java
@@ -1,11 +1,9 @@
 package kusuri12.teens_be.domain.auth.service;
 
-import kusuri12.teens_be.domain.auth.presentation.dto.request.RefreshTokenRequest;
-import kusuri12.teens_be.domain.auth.presentation.dto.response.TokenResponse;
-import kusuri12.teens_be.domain.user.domain.repository.UserRepository;
+import kusuri12.teens_be.domain.auth.presentation.dto.request.ReissueRequest;
 import kusuri12.teens_be.global.jwt.JwtTokenProvider;
-import kusuri12.teens_be.global.jwt.exception.InvalidJwtException;
-import kusuri12.teens_be.global.redis.RedisService;
+import kusuri12.teens_be.global.jwt.JwtTokens;
+import kusuri12.teens_be.global.jwt.exception.InvalidTokenException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,32 +13,28 @@ public class ReissueService {
 
     private final JwtTokenProvider jwtTokenProvider;
 
-    public TokenResponse reissue(RefreshTokenRequest request) {
+    public JwtTokens reissue(ReissueRequest request) {
 
-        String submittedRefreshToken = request.refreshToken();
+        String refreshToken = request.refreshToken();
 
         // 1. Refresh Token 유효성 검증 및 정보 추출
-        if (!jwtTokenProvider.validateToken(submittedRefreshToken)) {
-            throw InvalidJwtException.EXCEPTION;
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw InvalidTokenException.EXCEPTION;
         }
 
         // 2. Refresh Token에서 사용자 ID (Username) 추출
-        String username = jwtTokenProvider.getUsername(submittedRefreshToken);
+        String username = jwtTokenProvider.getUsername(refreshToken);
 
         // 3. Redis에 저장된 Refresh Token 조회
         String storedRefreshToken = jwtTokenProvider.getRefreshToken(username);
 
         // 4. 토큰 일치 여부 검증
         // 클라이언트가 보낸 토큰이 Redis에 저장된 토큰과 다르면, 토큰 탈취로 간주하고 모두 무효화
-        if (!submittedRefreshToken.equals(storedRefreshToken)) {
+        if (!refreshToken.equals(storedRefreshToken)) {
             jwtTokenProvider.deleteRefreshToken(username);
-            throw InvalidJwtException.EXCEPTION;
+            throw InvalidTokenException.EXCEPTION;
         }
 
-        String newAccessToken = jwtTokenProvider.reissueAccessToken(request.refreshToken());
-        String newRefreshToken = jwtTokenProvider.reissueRefreshToken(request.refreshToken());
-        jwtTokenProvider.saveRefreshToken(username, newRefreshToken);
-
-        return new TokenResponse(newAccessToken, newRefreshToken);
+        return jwtTokenProvider.reissueToken(refreshToken);
     }
 }

--- a/src/main/java/kusuri12/teens_be/domain/auth/service/SignInService.java
+++ b/src/main/java/kusuri12/teens_be/domain/auth/service/SignInService.java
@@ -5,6 +5,7 @@ import kusuri12.teens_be.domain.auth.presentation.dto.request.SignInRequest;
 import kusuri12.teens_be.domain.auth.presentation.dto.response.SignInResponse;
 import kusuri12.teens_be.global.auth.AuthDetails;
 import kusuri12.teens_be.global.jwt.JwtTokenProvider;
+import kusuri12.teens_be.global.jwt.JwtTokens;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -25,10 +26,8 @@ public class SignInService {
 
         AuthDetails authDetails = (AuthDetails) authentication.getPrincipal();
 
-        String accessToken = jwtTokenProvider.generateAccessToken(authDetails);
-        String refreshToken = jwtTokenProvider.generateRefreshToken(authDetails);
-        jwtTokenProvider.saveRefreshToken(authDetails.getUsername(), refreshToken);
+        JwtTokens jwtTokens = jwtTokenProvider.generateToken(authDetails);
 
-        return new SignInResponse(accessToken, refreshToken, authDetails);
+        return new SignInResponse(jwtTokens.accessToken(), jwtTokens.refreshToken(), authDetails);
     }
 }

--- a/src/main/java/kusuri12/teens_be/global/auth/AuthDetails.java
+++ b/src/main/java/kusuri12/teens_be/global/auth/AuthDetails.java
@@ -52,6 +52,7 @@ public class AuthDetails implements UserDetails {
         this.forumCount = user.getForumCount();
         this.commentCount = user.getCommentCount();
         this.profileImg = user.getProfileImg();
+
         List<GrantedAuthority> authList = new ArrayList<>();
         authList.add(new SimpleGrantedAuthority("ROLE_" + role));
         this.authorities = authList;

--- a/src/main/java/kusuri12/teens_be/global/config/SecurityConfig.java
+++ b/src/main/java/kusuri12/teens_be/global/config/SecurityConfig.java
@@ -1,26 +1,27 @@
 package kusuri12.teens_be.global.config;
 
 import kusuri12.teens_be.global.error.GlobalExceptionFilter;
+import kusuri12.teens_be.global.error.exception.ResponseWithErrorCode;
 import kusuri12.teens_be.global.error.handler.CustomAccessDeniedHandler;
 import kusuri12.teens_be.global.error.handler.CustomAuthenticationEntryPoint;
 import kusuri12.teens_be.global.jwt.JwtTokenFilter;
+import kusuri12.teens_be.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.annotation.web.configurers.CorsConfigurer;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.web.filter.CorsFilter;
 
 @Configuration
@@ -28,8 +29,8 @@ import org.springframework.web.filter.CorsFilter;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtTokenFilter jwtTokenFilter;
-    private final GlobalExceptionFilter globalExceptionFilter;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ResponseWithErrorCode responseWithErrorCode;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
@@ -37,8 +38,7 @@ public class SecurityConfig {
             "/auth/sign-up/**",
             "/auth/sign-in/**",
             "/auth/check-id/**",
-            "/auth/refresh/**",
-            "/auth/verify-email/**",
+            "/auth/reissue",
 
             "/swagger-ui.html",
             "/v3/api-docs/**",
@@ -49,7 +49,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(CsrfConfigurer::disable)
-                .cors(CorsConfigurer::disable)
+                .cors(Customizer.withDefaults())
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session
@@ -73,8 +73,8 @@ public class SecurityConfig {
                         .requestMatchers("/information/**").hasRole("ADMIN")
                         .anyRequest().hasRole("USER"))
 
-                .addFilterBefore(globalExceptionFilter, CorsFilter.class)
-                .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(globalExceptionFilter(), CorsFilter.class)
+                .addFilterBefore(jwtTokenFilter(), UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 
@@ -88,5 +88,15 @@ public class SecurityConfig {
         // 인증 처리를 위한 AuthenticationManager를 Bean 등록
         // 주로 로그인 시도 시 사용자 인증 로직에 사용됨
         return config.getAuthenticationManager();
+    }
+
+    @Bean
+    public GlobalExceptionFilter globalExceptionFilter() {
+        return new GlobalExceptionFilter(responseWithErrorCode);
+    }
+
+    @Bean
+    public JwtTokenFilter jwtTokenFilter() {
+        return new JwtTokenFilter(jwtTokenProvider);
     }
 }

--- a/src/main/java/kusuri12/teens_be/global/config/WebConfig.java
+++ b/src/main/java/kusuri12/teens_be/global/config/WebConfig.java
@@ -1,0 +1,16 @@
+package kusuri12.teens_be.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:8080")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowCredentials(true);
+    }
+}

--- a/src/main/java/kusuri12/teens_be/global/error/GlobalExceptionFilter.java
+++ b/src/main/java/kusuri12/teens_be/global/error/GlobalExceptionFilter.java
@@ -1,30 +1,26 @@
 package kusuri12.teens_be.global.error;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.sentry.Sentry;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import kusuri12.teens_be.global.error.exception.ErrorCode;
-import kusuri12.teens_be.global.error.exception.ErrorResponse;
+import kusuri12.teens_be.global.error.exception.ResponseWithErrorCode;
 import kusuri12.teens_be.global.error.exception.TeensException;
-import kusuri12.teens_be.global.jwt.exception.ExpiredJwtException;
-import kusuri12.teens_be.global.jwt.exception.InvalidJwtException;
+import kusuri12.teens_be.global.jwt.exception.ExpiredTokenException;
+import kusuri12.teens_be.global.jwt.exception.InvalidTokenException;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-@Component
 @Slf4j
 @RequiredArgsConstructor
 public class GlobalExceptionFilter extends OncePerRequestFilter {
 
-    private final ObjectMapper mapper;
+    private final ResponseWithErrorCode responseWithErrorCode;
 
     @Override
     protected void doFilterInternal(
@@ -33,30 +29,19 @@ public class GlobalExceptionFilter extends OncePerRequestFilter {
             @NonNull FilterChain chain) throws IOException {
         try {
             chain.doFilter(request, response);
-        } catch (ExpiredJwtException e) {
+        } catch (ExpiredTokenException e) {
             log.error("ExpiredJwtException catch : {}", e.getMessage());
-            responseWithErrorCode(response, ErrorCode.EXPIRED_JWT);
-        } catch (InvalidJwtException e) {
+            responseWithErrorCode.response(response, ErrorCode.EXPIRED_JWT);
+        } catch (InvalidTokenException e) {
             log.error("InvalidJwtException catch : {}", e.getMessage());
-            responseWithErrorCode(response, ErrorCode.INVALID_JWT);
+            responseWithErrorCode.response(response, ErrorCode.INVALID_JWT);
         } catch (TeensException e) {
             log.error("Handled TeensException : ", e);
-            responseWithErrorCode(response, e.getErrorCode());
+            responseWithErrorCode.response(response, e.getErrorCode());
         } catch (Exception e) {
             log.error("Unhandled Exception : ", e);
-            responseWithErrorCode(response, ErrorCode.INTERNAL_SERVER_ERROR);
+            responseWithErrorCode.response(response, ErrorCode.INTERNAL_SERVER_ERROR);
             Sentry.captureException(e);
         }
-    }
-
-    private void responseWithErrorCode(HttpServletResponse response, ErrorCode errorCode) throws IOException {
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .status(errorCode.getStatus())
-                .message(errorCode.getMessage())
-                .build();
-
-        response.setStatus(errorCode.getStatus().value());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        mapper.writeValue(response.getOutputStream(), errorResponse);
     }
 }

--- a/src/main/java/kusuri12/teens_be/global/error/exception/ErrorCode.java
+++ b/src/main/java/kusuri12/teens_be/global/error/exception/ErrorCode.java
@@ -22,9 +22,11 @@ public enum ErrorCode {
     EXPIRED_JWT(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     INVALID_JWT(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "로그인 후 이용할 수 있습니다."),
 
     NO_AUTHOR(HttpStatus.FORBIDDEN, "작성자만 수정할 수 있습니다."),
     NO_ADMIN(HttpStatus.FORBIDDEN, "정보 게시판은 관리자만 관리할 수 있습니다."),
+    FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
     TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "토큰을 찾을 수 없습니다."),

--- a/src/main/java/kusuri12/teens_be/global/error/exception/ResponseWithErrorCode.java
+++ b/src/main/java/kusuri12/teens_be/global/error/exception/ResponseWithErrorCode.java
@@ -1,0 +1,35 @@
+package kusuri12.teens_be.global.error.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ResponseWithErrorCode {
+
+    private final ObjectMapper mapper;
+
+    public void response(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .status(errorCode.getStatus())
+                .message(errorCode.getMessage())
+                .build();
+
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        try {
+            String jsonResponse = mapper.writeValueAsString(errorResponse);
+            response.getWriter().write(jsonResponse);
+        } catch (Exception e) {
+            log.error("Error occurred while writing response: {}", e.getMessage());
+            throw e;
+        }
+    }
+}

--- a/src/main/java/kusuri12/teens_be/global/error/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/kusuri12/teens_be/global/error/handler/CustomAccessDeniedHandler.java
@@ -2,6 +2,9 @@ package kusuri12.teens_be.global.error.handler;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import kusuri12.teens_be.global.error.exception.ErrorCode;
+import kusuri12.teens_be.global.error.exception.ResponseWithErrorCode;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
@@ -10,7 +13,10 @@ import java.io.IOException;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ResponseWithErrorCode responseWithErrorCode;
 
     @Override
     public void handle(
@@ -18,14 +24,8 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
             HttpServletResponse response,
             AccessDeniedException accessDeniedException) throws IOException {
 
-        // 💡 1. 403 에러 발생 시 로그 출력
         log.error("Access Denied: {}", accessDeniedException.getMessage(), accessDeniedException);
 
-        // 💡 2. 클라이언트에게 403 응답 전달 (Spring Security가 기본적으로 하지만 명확하게)
-        response.setStatus(HttpServletResponse.SC_FORBIDDEN); // 403
-
-        // JSON 응답 본문을 보내고 싶다면 여기서 처리 (선택 사항)
-        // response.setContentType("application/json;charset=UTF-8");
-        // response.getWriter().write("{ \"error\": \"Access Denied\", \"message\": \"" + accessDeniedException.getMessage() + "\" }");
+        responseWithErrorCode.response(response, ErrorCode.FORBIDDEN_ACCESS);
     }
 }

--- a/src/main/java/kusuri12/teens_be/global/error/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/kusuri12/teens_be/global/error/handler/CustomAuthenticationEntryPoint.java
@@ -2,6 +2,9 @@ package kusuri12.teens_be.global.error.handler;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import kusuri12.teens_be.global.error.exception.ErrorCode;
+import kusuri12.teens_be.global.error.exception.ResponseWithErrorCode;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -10,10 +13,10 @@ import java.io.IOException;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-    // JSON 응답을 위한 ObjectMapper를 사용할 수도 있지만, 여기서는 간단하게 처리합니다.
-    // private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ResponseWithErrorCode responseWithErrorCode;
 
     @Override
     public void commence(
@@ -21,20 +24,9 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
             HttpServletResponse response,
             AuthenticationException authException) throws IOException {
 
-        // 💡 1. 401 에러 발생 시 로그 출력
-        // 토큰이 없거나, 만료되었거나, 서명이 유효하지 않을 때 발생
         log.warn("Unauthorized Access Attempt: {}", authException.getMessage());
         log.warn("Request URI: {}", request.getRequestURI());
 
-        // 💡 2. 클라이언트에게 401 응답 전달
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
-
-        // JSON 응답 본문을 보내 클라이언트에게 상세 정보를 제공
-        response.setContentType("application/json;charset=UTF-8");
-        response.getWriter().write("{"
-                + "\"status\": 401,"
-                + "\"error\": \"Unauthorized\","
-                + "\"message\": \"인증에 실패하였습니다: 유효하지 않거나 만료된 토큰\""
-                + "}");
+        responseWithErrorCode.response(response, ErrorCode.UNAUTHORIZED_ACCESS);
     }
 }

--- a/src/main/java/kusuri12/teens_be/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/kusuri12/teens_be/global/error/handler/GlobalExceptionHandler.java
@@ -57,7 +57,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             HttpHeaders headers,
             HttpStatusCode status,
             WebRequest request) {
-
         log.error("HttpMessageNotReadableException: {}", ex.getMessage());
 
         ErrorCode errorCode = ErrorCode.REQUEST_NOT_READABLE;
@@ -74,6 +73,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<ErrorResponse> handleTeensException(TeensException e) {
         log.error("TeensException: {}", e.getMessage());
 
+
         ErrorCode errorCode = e.getErrorCode();
         ErrorResponse response = ErrorResponse.builder()
                 .status(errorCode.getStatus())
@@ -88,7 +88,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     // Security 관련 인증 실패 처리
     @ExceptionHandler({BadCredentialsException.class, UsernameNotFoundException.class})
     public ResponseEntity<ErrorResponse> handleAuthenticationException(Exception e) {
-        log.error("Authentication Exception: {}", e.getMessage());
+        log.warn("Login Failed: {}", e.getMessage());
 
         ErrorCode errorCode = ErrorCode.INVALID_CREDENTIALS;
         ErrorResponse response = ErrorResponse.builder()

--- a/src/main/java/kusuri12/teens_be/global/jwt/JwtProperties.java
+++ b/src/main/java/kusuri12/teens_be/global/jwt/JwtProperties.java
@@ -1,0 +1,14 @@
+package kusuri12.teens_be.global.jwt;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+    private final String secret;
+    private final long accessTokenExpiration;
+    private final long refreshTokenExpiration;
+}

--- a/src/main/java/kusuri12/teens_be/global/jwt/JwtTokenFilter.java
+++ b/src/main/java/kusuri12/teens_be/global/jwt/JwtTokenFilter.java
@@ -5,10 +5,9 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import kusuri12.teens_be.domain.auth.service.SignOutService;
 import kusuri12.teens_be.global.auth.AuthDetails;
-import kusuri12.teens_be.global.jwt.exception.ExpiredJwtException;
-import kusuri12.teens_be.global.jwt.exception.InvalidJwtException;
+import kusuri12.teens_be.global.jwt.exception.ExpiredTokenException;
+import kusuri12.teens_be.global.jwt.exception.InvalidTokenException;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -17,11 +16,9 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
-import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import javax.swing.*;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -29,7 +26,6 @@ import java.util.stream.Collectors;
 
 import static kusuri12.teens_be.global.config.SecurityConfig.PERMITTED_AUTH;
 
-@Component
 @RequiredArgsConstructor
 // OncePerRequestFilter: 상속받은 클래스가 해당 필터를 한 번 실행할 수 있도록 함
 public class JwtTokenFilter extends OncePerRequestFilter {
@@ -39,7 +35,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        String path = request.getRequestURI();
+        String path = request.getServletPath();
         String method = request.getMethod();
 
         if ("OPTIONS".equals(method)) {
@@ -48,14 +44,12 @@ public class JwtTokenFilter extends OncePerRequestFilter {
 
         return Arrays.stream(PERMITTED_AUTH)
                 .anyMatch(permit -> matcher.match(permit, path));
-
     }
 
     @Override
-    protected void doFilterInternal(@NonNull HttpServletRequest request, // HTTP request를 담고 있는 클래스
-                                    @NonNull HttpServletResponse response, // HTTP response를 담는 클래스
-                                    @NonNull FilterChain chain // Spring의 Filter들을 체인처럼 연결해 놓은 클래스
-                                    ) throws ServletException, IOException {
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain chain) throws ServletException, IOException {
         String jwt = jwtTokenProvider.getJwt(request);
 
         if (jwt == null) {
@@ -64,29 +58,23 @@ public class JwtTokenFilter extends OncePerRequestFilter {
         }
 
         try {
-            // 토큰 파싱 및 유효성 검사
             Claims claims = jwtTokenProvider.parse(jwt);
-
             String tokenType = claims.get("tokenType", String.class);
             String username = claims.getSubject();
             Long userId = claims.get("userId", Long.class);
             String authoritiesStr = claims.get("authorities", String.class);
 
-            // ACCESS 토큰이고 필수 클레임이 존재할 경우
             if ("ACCESS".equals(tokenType) && username != null && userId != null) {
-
                 if (jwtTokenProvider.isBlackList(jwt)) {
-                    throw InvalidJwtException.EXCEPTION;
+                    throw InvalidTokenException.EXCEPTION;
                 }
 
-                // 권한 파싱
                 List<GrantedAuthority> authorities = Arrays.stream(authoritiesStr.split(","))
                         .map(SimpleGrantedAuthority::new)
                         .collect(Collectors.toList());
 
                 UserDetails userDetails = new AuthDetails(userId, username, authorities);
 
-                // 인증 객체 생성 및 Security Context에 설정
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 
@@ -95,10 +83,10 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             }
 
             chain.doFilter(request, response);
-        } catch (ExpiredJwtException e) {
-            throw ExpiredJwtException.EXCEPTION;
-        } catch (InvalidJwtException e) {
-            throw InvalidJwtException.EXCEPTION;
+        } catch (ExpiredTokenException e) {
+            throw ExpiredTokenException.EXCEPTION;
+        } catch (InvalidTokenException e) {
+            throw InvalidTokenException.EXCEPTION;
         }
     }
 }

--- a/src/main/java/kusuri12/teens_be/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/kusuri12/teens_be/global/jwt/JwtTokenProvider.java
@@ -1,6 +1,8 @@
 package kusuri12.teens_be.global.jwt;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,83 +12,76 @@ import kusuri12.teens_be.domain.user.domain.User;
 import kusuri12.teens_be.domain.user.domain.repository.UserRepository;
 import kusuri12.teens_be.domain.user.exception.UserNotFoundException;
 import kusuri12.teens_be.global.auth.AuthDetails;
-import kusuri12.teens_be.global.jwt.exception.ExpiredJwtException;
-import kusuri12.teens_be.global.jwt.exception.InvalidJwtException;
+import kusuri12.teens_be.global.jwt.exception.ExpiredTokenException;
+import kusuri12.teens_be.global.jwt.exception.InvalidTokenException;
 import kusuri12.teens_be.global.redis.RedisService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
-import java.time.Duration;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Date;
 import java.util.stream.Collectors;
 
 @Component
 public class JwtTokenProvider {
 
+    private final JwtProperties jwtProperties;
     private final SecretKey key;
-    private final long accessTokenExpiration;
-    private final long refreshTokenExpiration;
     private final RedisService redisService;
-    private final RefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
 
     public JwtTokenProvider(
-            @Value("${jwt.secret}") String secretKey,
-            @Value("${jwt.access-token-expiration}") long accessTokenExpiration,
-            @Value("${jwt.refresh-token-expiration}") long refreshTokenExpiration,
+            JwtProperties jwtProperties,
             RedisService redisService,
             RefreshTokenRepository refreshTokenRepository,
             UserRepository userRepository) {
-        this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
-        this.accessTokenExpiration = accessTokenExpiration;
-        this.refreshTokenExpiration = refreshTokenExpiration;
+        this.jwtProperties = jwtProperties;
+        this.key = Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes());
         this.redisService = redisService;
-        this.refreshTokenRepository = refreshTokenRepository;
         this.userRepository = userRepository;
     }
 
-    public String generateToken(AuthDetails authDetails, String type, Long ext) {
-        LocalDateTime now = LocalDateTime.now();
+    // 토큰 쌍 생성
+    public JwtTokens generateToken(AuthDetails authDetails) {
+        Instant now = Instant.now();
 
-        Date expiresAt = Date.from(now.plusSeconds(ext)
-                .atZone(ZoneId.systemDefault()).toInstant());
+        Date issuedAt = Date.from(now);
+        Date accessExp = Date.from(now.plusSeconds(jwtProperties.getAccessTokenExpiration()));
+        Date refreshExp = Date.from(now.plusSeconds(jwtProperties.getRefreshTokenExpiration()));
 
         String authorities = authDetails.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
 
-        return Jwts.builder()
-                .setSubject(authDetails.getUsername())
-                .claim("userId", authDetails.getId())
+        String accessToken = Jwts.builder()
+                .subject(authDetails.getUsername())
                 .claim("authorities", authorities)
-                .claim("tokenType", type)
-                .issuedAt(new Date())
-                .expiration(expiresAt)
+                .claim("tokenType", "ACCESS")
+                .issuedAt(issuedAt)
+                .expiration(accessExp)
                 .signWith(key, Jwts.SIG.HS512)
                 .compact();
-    }
 
-    public String generateAccessToken(AuthDetails authDetails) {
-        return generateToken(authDetails, "ACCESS", accessTokenExpiration);
-    }
-
-    public String generateRefreshToken(AuthDetails authDetails) {
-        String refreshToken = generateToken(authDetails, "REFRESH", refreshTokenExpiration);
+        String refreshToken = Jwts.builder()
+                .subject(authDetails.getUsername())
+                .claim("tokenType", "REFRESH")
+                .issuedAt(issuedAt)
+                .expiration(refreshExp)
+                .signWith(key, Jwts.SIG.HS512)
+                .compact();
 
         String key = "RT:" + authDetails.getUsername();
         redisService.set(
                 key,
                 refreshToken,
-                refreshTokenExpiration
+                jwtProperties.getRefreshTokenExpiration()
         );
 
-        return refreshToken;
+        return JwtTokens.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
     }
 
     // Token Body를 얻는 메서드
@@ -97,10 +92,10 @@ public class JwtTokenProvider {
                     .build()
                     .parseSignedClaims(token)
                     .getPayload();
-        } catch (io.jsonwebtoken.ExpiredJwtException e){
-            throw ExpiredJwtException.EXCEPTION;
-        } catch (io.jsonwebtoken.JwtException | IllegalArgumentException e) {
-            throw InvalidJwtException.EXCEPTION;
+        } catch (ExpiredTokenException e){
+            throw ExpiredTokenException.EXCEPTION;
+        } catch (JwtException | IllegalArgumentException e) {
+            throw InvalidTokenException.EXCEPTION;
         }
     }
 
@@ -113,53 +108,41 @@ public class JwtTokenProvider {
         }
     }
 
-    public String reissueAccessToken(String refreshToken) {
+    // access 토큰이 만료되었을 때
+    public JwtTokens reissueToken(String refreshToken) {
         String username = getUsername(refreshToken);
-        RefreshToken storedToken = refreshTokenRepository.findByToken(refreshToken);
-
-        if (!storedToken.getUsername().equals(username)) {
-            throw InvalidJwtException.EXCEPTION;
-        }
-
-        User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> UserNotFoundException.EXCEPTION);
-        AuthDetails authDetails = new AuthDetails(user);
-
-        return generateAccessToken(authDetails);
-    }
-
-    public String reissueRefreshToken(String oldRefreshToken) {
-        String username = getUsername(oldRefreshToken);
 
         // Redis에서 기존 토큰 확인
-        RefreshToken storedToken = refreshTokenRepository.findByToken(oldRefreshToken);
+        Object storedToken = redisService.get("RT:" + username);
 
-        // username 일치 확인
-        if (!storedToken.getUsername().equals(username)) {
-            throw InvalidJwtException.EXCEPTION;
+        // null 확인
+        if (storedToken == null) {
+            throw InvalidTokenException.EXCEPTION;
         }
 
         // 기존 Refresh Token 삭제
-        refreshTokenRepository.delete(storedToken);
+        redisService.delete("RT:" + username);
 
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> UserNotFoundException.EXCEPTION);
         AuthDetails authDetails = new AuthDetails(user);
 
-        // 새로운 Refresh Token 발급
-        return generateRefreshToken(authDetails);
+        return generateToken(authDetails);
     }
 
     public String getUsername(String token) {
-        return parse(token).getSubject();
-    }
-
-    public Long getUserId(String token) {
-        return parse(token).get("userId", Long.class);
-    }
-
-    public String getTokenType(String token) {
-        return parse(token).get("tokenType", String.class);
+        try {
+            return Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .getSubject();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims().getSubject();
+        } catch (JwtException e) {
+            throw InvalidTokenException.EXCEPTION;
+        }
     }
 
     public String getRefreshToken(String username) {
@@ -205,10 +188,5 @@ public class JwtTokenProvider {
     public void deleteRefreshToken(String username) {
         // 키 생성 규칙(RT:) 및 Redis 접근 로직을 Provider가 캡슐화
         redisService.delete("RT:" + username);
-    }
-
-    public void saveRefreshToken(String username, String refreshToken) {
-        String key = "RT:" + username;
-        redisService.set(key, refreshToken, refreshTokenExpiration);
     }
 }

--- a/src/main/java/kusuri12/teens_be/global/jwt/JwtTokens.java
+++ b/src/main/java/kusuri12/teens_be/global/jwt/JwtTokens.java
@@ -1,0 +1,9 @@
+package kusuri12.teens_be.global.jwt;
+
+import lombok.Builder;
+
+@Builder
+public record JwtTokens(
+        String accessToken,
+        String refreshToken
+) {}

--- a/src/main/java/kusuri12/teens_be/global/jwt/exception/ExpiredTokenException.java
+++ b/src/main/java/kusuri12/teens_be/global/jwt/exception/ExpiredTokenException.java
@@ -3,9 +3,9 @@ package kusuri12.teens_be.global.jwt.exception;
 import kusuri12.teens_be.global.error.exception.ErrorCode;
 import kusuri12.teens_be.global.error.exception.TeensException;
 
-public class ExpiredJwtException extends TeensException {
-    public static final ExpiredJwtException EXCEPTION = new ExpiredJwtException();
-    private ExpiredJwtException() {
+public class ExpiredTokenException extends TeensException {
+    public static final ExpiredTokenException EXCEPTION = new ExpiredTokenException();
+    private ExpiredTokenException() {
         super(ErrorCode.EXPIRED_JWT);
     }
 }

--- a/src/main/java/kusuri12/teens_be/global/jwt/exception/InvalidTokenException.java
+++ b/src/main/java/kusuri12/teens_be/global/jwt/exception/InvalidTokenException.java
@@ -3,9 +3,9 @@ package kusuri12.teens_be.global.jwt.exception;
 import kusuri12.teens_be.global.error.exception.ErrorCode;
 import kusuri12.teens_be.global.error.exception.TeensException;
 
-public class InvalidJwtException extends TeensException {
-    public static final InvalidJwtException EXCEPTION = new InvalidJwtException();
-    private InvalidJwtException() {
+public class InvalidTokenException extends TeensException {
+    public static final InvalidTokenException EXCEPTION = new InvalidTokenException();
+    private InvalidTokenException() {
         super(ErrorCode.INVALID_JWT);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:3306}/${MYSQL_NAME:teens}?allowPublicKeyRetrieval=true&useSSL=false&characterEncoding=UTF-8&useUnicode=true&connectionCollation=utf8mb4_general_ci
-    username: root
+    username: ${DB_USERNAME:root}
     password: ${PASSWORD}
 
   data:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -21,7 +21,7 @@ validation.verify-code.blank=인증 코드를 입력해주세요.
 
 # -- title --
 validation.title.blank=제목을 입력해주세요.
-validation.title.length=제목은 2000자를 넘을 수 없습니다.
+validation.title.length=제목은 200자를 넘을 수 없습니다.
 validation.title.ban=부적절한 내용이 들어가 있습니다.
 
 # -- content --


### PR DESCRIPTION
- Token response -> JwtTokens global DTO 사용
- jwt 토큰 발급 방식을 토큰 쌍으로 발급하도록 변경
- jwt properties class를 만들어 jwt 프로퍼티 관리, @Value 어노테이션 제거
- jwt provider에서 중복되는 코드 제거 및 reissueToken 메서드 리팩토링
- jwt 필터의 jwt null 검사를 먼저 하도록 변경
- responseWithErrorCode 클래스 추가, 필터 및 핸들러에서 사용
- 필터에서 @component 어노테이션 제거, security config에서 빈 등록 방식으로 변경
- cors 설정 추가